### PR TITLE
Rename auth headers

### DIFF
--- a/lib/teilashare/request.rb
+++ b/lib/teilashare/request.rb
@@ -11,8 +11,8 @@ module Teilashare
 
     def call
       connection.get(request_url) do |req|
-        req.headers['x-Shareashare-Date'] = auth.date_string
-        req.headers['x-Shareashare-Authentication'] = auth.hash
+        req.headers['x-ShareASale-Date'] = auth.date_string
+        req.headers['x-ShareASale-Authentication'] = auth.hash
       end
     end
 

--- a/lib/teilashare/version.rb
+++ b/lib/teilashare/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Teilashare
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
During renaming of the Gem from shareasale to teilashare, the auth headers were mispelt. 